### PR TITLE
Increase default max buffer size

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,12 @@ try {
             checkCategoryOrHigher = val;
         }
     });
-    
-    childProcess.exec('npm audit --json', function (error, stdout, stderr){
+
+    const childProcessOptions = {
+      maxBuffer: 1000 * 1000 * 10, // 10 MB
+    }
+
+    childProcess.exec('npm audit --json', childProcessOptions, function (error, stdout, stderr) {
         try{
             JSON.parse(stdout);
             if(typeof stderror == 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-security",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This PR fixes an issue where the process would panic on projects with lots of dependencies.

The cause is that the output of `npm audit --json` might exceed the default childprocess memory limit, causing the process to be killed.

```
maxBuffer <number> Largest amount of data in bytes allowed on stdout or stderr. If exceeded, the child process is terminated and any output is truncated. See caveat at maxBuffer and Unicode. Default: 1024 * 1024.
```
Source:
https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback